### PR TITLE
Substitute Freitagsfoo template if Event template isn't present

### DIFF
--- a/extern/current_events
+++ b/extern/current_events
@@ -351,9 +351,26 @@ sub get_data_from_template {
 
 	my @lines       = split( /\n/, mw_get($pagename) );
 	my $in_template = 0;
+	my $has_seen_template = 0;
 	for my $line (@lines) {
 		if ( $line =~ m/ ^ \s* \{\{ \s* Event \s* /ox ) {
 			$in_template = 1;
+			$has_seen_template = 1;
+		}
+		if ($line =~ m/ ^ \s* \{\{ \s* Freitagsfoo \s* /ox and not $has_seen_template ) {
+			print $line;
+			my $content = join( "\n", @lines );
+			$content =~ s/\{\{\s*Freitagsfoo/\{\{subst:Freitagsfoo /;
+			if ( my $ref = $mw->api( {
+				action => 'parse',
+				title => $pagename,
+				text => $content,
+				pst => 1,
+				onlypst => 1
+		} ) ) {
+				$content = $ref->{parse}->{text}->{"*"};
+				@lines = split( /\n/, $content);
+			}
 		}
 		if ( $in_template
 			and ( $line =~ m{ \| \s* date \s* = \s* (?<date> .+ ) $ }ix ) )


### PR DESCRIPTION
If we're just going to use `{{Freitagsfoo | Date=1970-01-01 | Host=FIXME }}` on Freitagsfoo pages, there won't be an `Event` template on that page.
Simply subsituting the template works.

(I think we should probably move the `Event` template to the general Freitagsfoo page, but that's a different story.)